### PR TITLE
Content Security Policy Support

### DIFF
--- a/src/Blade.php
+++ b/src/Blade.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Rawilk\Blade;
 
+use Illuminate\Support\Facades\Vite;
+
 final class Blade
 {
     public function javaScript(array $options = []): string
@@ -18,6 +20,7 @@ final class Blade
     private function javaScriptAssets(array $options = []): string
     {
         $assetsUrl = config('blade.asset_url') ?: rtrim($options['asset_url'] ?? '', '/');
+        $nonce = $this->getNonce($options);
 
         $manifest = json_decode(file_get_contents(__DIR__ . '/../dist/manifest.json'), true);
         $versionedFileName = $manifest['/blade.js'];
@@ -25,7 +28,26 @@ final class Blade
         $fullAssetPath = "{$assetsUrl}/blade{$versionedFileName}";
 
         return <<<HTML
-        <script src="{$fullAssetPath}" data-turbo-eval="false" data-turbolinks-eval="false"></script>
+        <script src="{$fullAssetPath}" data-turbo-eval="false" data-turbolinks-eval="false" {$nonce}></script>
         HTML;
+    }
+
+    private function getNonce(array $options): string
+    {
+        if (isset($options['nonce'])) {
+            return "nonce=\"{$options['nonce']}\"";
+        }
+
+        // If there is a csp package installed, i.e. spatie/laravel-csp, we'll check for the existence of the helper function.
+        if (function_exists('csp_nonce') && $nonce = csp_nonce()) {
+            return "nonce=\"{$nonce}\"";
+        }
+
+        // Lastly, we'll check for the existence of a csp nonce from Vite.
+        if (class_exists(Vite::class) && $nonce = Vite::cspNonce()) {
+            return "nonce=\"{$nonce}\"";
+        }
+
+        return '';
     }
 }

--- a/tests/Unit/AssetsDirectiveTest.php
+++ b/tests/Unit/AssetsDirectiveTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Str;
+use Rawilk\Blade\Facades\Blade;
+
+it('outputs the script source', function () {
+    $this->assertStringContainsString(
+        '<script src="/blade/blade.js?',
+        Blade::javaScript(),
+    );
+});
+
+it('outputs a comment when app is in debug mode', function () {
+    config()->set('app.debug', true);
+
+    $this->assertStringContainsString(
+        '<!-- Blade Scripts -->',
+        Blade::javaScript(),
+    );
+});
+
+it('does not output a comment when not in debug mode', function () {
+    config()->set('app.debug', false);
+
+    $this->assertStringNotContainsString(
+        '<!-- Blade Scripts -->',
+        Blade::javaScript(),
+    );
+});
+
+it('can use a custom asset url', function () {
+    config()->set('blade.asset_url', 'https://example.com');
+
+    $this->assertStringContainsString(
+        '<script src="https://example.com/blade/blade.js?',
+        Blade::javaScript(),
+    );
+});
+
+it('accepts an asset url as an argument', function () {
+    $this->assertStringContainsString(
+        '<script src="https://example.com/blade/blade.js?',
+        Blade::javaScript(['asset_url' => 'https://example.com']),
+    );
+});
+
+it('can output a nonce on the script tag', function () {
+    $nonce = Str::random(32);
+
+    $this->assertStringContainsString(
+        "nonce=\"{$nonce}\"",
+        Blade::javaScript(['nonce' => $nonce]),
+    );
+});

--- a/tests/Unit/TagCompilerTest.php
+++ b/tests/Unit/TagCompilerTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Rawilk\Blade\Support\BladeTagCompiler;
+
+beforeEach(function () {
+    $this->compiler = new BladeTagCompiler;
+});
+
+it('compiles the scripts tag', function (string $tag) {
+    $result = $this->compiler->compile($tag);
+
+    expect('@bladeScripts')->toBe($result);
+})->with([
+    '<blade:scripts />',
+    '<blade:javaScript />',
+]);


### PR DESCRIPTION
When implementing a [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP), a common way to allow script files is to use a nonce. This will allow you to specify a nonce to be rendered onto the package scripts by one of the following ways:

- Send it through as an option via the `@bladeScripts` blade directive (The `<blade:scripts />` custom tag does not support this)
```html
@bladeScripts(['nonce' => 'my-nonce'])
```
- Pull in a csp package (such as https://github.com/spatie/laravel-csp)
- Enable `cspNonce` through Vite in a service provider:
```php
Vite::useCspNonce();
```

