### PR TITLE
Add script component

### DIFF
--- a/config/blade.php
+++ b/config/blade.php
@@ -118,6 +118,7 @@ return [
         'button' => Components\Button\Button::class,
         'card' => Components\Card\Card::class,
         'link' => Components\Navigation\Link::class,
+        'script' => Components\Tags\Script::class,
     ],
 
     /*

--- a/resources/views/components/tags/script.blade.php
+++ b/resources/views/components/tags/script.blade.php
@@ -1,0 +1,3 @@
+<script {{ $attributes }} @if ($nonce) nonce="{{ $nonce }}" @endif>
+    {{ $slot }}
+</script>

--- a/src/Components/Tags/Script.php
+++ b/src/Components/Tags/Script.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rawilk\Blade\Components\Tags;
+
+use Illuminate\Support\Facades\Vite;
+use Rawilk\Blade\Components\BladeComponent;
+
+/**
+ * This component is honestly overkill unless you don't want to deal with
+ * setting a nonce manually everytime you need an inline script.
+ */
+class Script extends BladeComponent
+{
+    public function __construct(public ?string $nonce = null)
+    {
+        $this->nonce = $nonce ?? $this->getNonce();
+    }
+
+    protected function getNonce(): ?string
+    {
+        // If there is a csp package installed, i.e. spatie/laravel-csp, we'll try and use that first.
+        if (function_exists('csp_nonce')) {
+            return csp_nonce();
+        }
+
+        // If that failed, we'll try to check for the existence of a nonce from vite.
+        if (class_exists(Vite::class)) {
+            return Vite::cspNonce();
+        }
+
+        return null;
+    }
+}

--- a/tests/Components/Tags/ScriptTest.php
+++ b/tests/Components/Tags/ScriptTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Blade as LaravelBlade;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Vite;
+use Illuminate\Support\Str;
+use function Pest\Laravel\get;
+use Sinnbeck\DomAssertions\Asserts\AssertElement;
+
+it('renders a script tag', function () {
+    $template = <<<'HTML'
+    <x-blade::tags.script>
+        console.log('Hello world!');
+    </x-blade::tags.script>
+    HTML;
+
+    Route::get('/test', fn () => LaravelBlade::render($template));
+
+    get('/test')
+        ->assertSee('console.log(\'Hello world!\');', false)
+        ->assertElementExists('script', function (AssertElement $script) {
+            $script->is('script');
+        });
+});
+
+it('renders attributes onto the script tag', function () {
+    Route::get('/test', fn () => LaravelBlade::render('<x-blade::tags.script src="https://example.com" />'));
+
+    get('/test')
+        ->assertElementExists('script', function (AssertElement $script) {
+            $script->has('src', 'https://example.com');
+        });
+});
+
+it('accepts a nonce', function () {
+    $nonce = Str::random(32);
+    Route::get('/test', fn () => LaravelBlade::render("<x-blade::tags.script nonce=\"{$nonce}\" />"));
+
+    get('/test')
+        ->assertElementExists('script', function (AssertElement $script) use ($nonce) {
+            $script->has('nonce', $nonce);
+        });
+});
+
+it('renders a nonce automatically if one is set in Vite', function () {
+    Vite::useCspNonce();
+
+    $nonce = Vite::cspNonce();
+
+    Route::get('/test', fn () => LaravelBlade::render('<x-blade::tags.script />'));
+
+    get('/test')
+        ->assertElementExists('script', function (AssertElement $script) use ($nonce) {
+            $script->has('nonce', $nonce);
+        });
+})->skip(! class_exists(Vite::class), 'Vite is not installed.');
+
+it('renders a nonce automatically if one is set in spatie/laravel-csp', function () {
+    function csp_nonce(): string
+    {
+        return 'my_nonce';
+    }
+
+    Route::get('/test', fn () => LaravelBlade::render('<x-blade::tags.script />'));
+
+    get('/test')
+        ->assertElementExists('script', function (AssertElement $script) {
+            $script->has('nonce', 'my_nonce');
+        });
+});


### PR DESCRIPTION
PR adds a component to render a `<script>` tag. The main advantage of this component is being able to automatically render an inline script with a `nonce` attribute on it if a nonce is present from Vite or a package to help comply with a content security policy.
