### PR TITLE
Require strict types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "blade-ui-kit/blade-heroicons": "^2.1",
         "laravel/pint": "^1.5",
         "livewire/livewire": "^2.11",
-        "nunomaduro/collision": "^7.0",
+        "nunomaduro/collision": "^6.0|^7.0",
         "orchestra/testbench": "^7.0|^8.0",
         "pestphp/pest": "^1.22|^2.0",
         "pestphp/pest-plugin-laravel": "^1.3|^2.0",

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         "blade-ui-kit/blade-heroicons": "^2.1",
         "laravel/pint": "^1.5",
         "livewire/livewire": "^2.11",
-        "nunomaduro/collision": "^6.0",
+        "nunomaduro/collision": "^7.0",
         "orchestra/testbench": "^7.0|^8.0",
-        "pestphp/pest": "^1.22",
-        "pestphp/pest-plugin-laravel": "^1.3",
+        "pestphp/pest": "^1.22|^2.0",
+        "pestphp/pest-plugin-laravel": "^1.3|^2.0",
         "sinnbeck/laravel-dom-assertions": "^1.1",
         "spatie/laravel-ray": "^1.31"
     },

--- a/config/blade.php
+++ b/config/blade.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Rawilk\Blade\Components;
 
 return [

--- a/pint.json
+++ b/pint.json
@@ -7,6 +7,7 @@
         "types_spaces": {
             "space": "none"
         },
-        "single_trait_insert_per_statement": true
+        "single_trait_insert_per_statement": true,
+        "declare_strict_types": true
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Rawilk\Blade\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);


### PR DESCRIPTION
Update pint configuration to automatically add `declare(strict_types=1)` to all php files.
